### PR TITLE
Install cypress globally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM cypress/base:10
 
-RUN npm install cypress
+RUN npm install -g cypress
 
 ENV TZ "America/New_York"
 


### PR DESCRIPTION
Should we be installing this globally? I think it's still getting installed during the build.